### PR TITLE
The helm chart package of prometheus-adapter supports arm64

### DIFF
--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -2,7 +2,7 @@
 affinity: {}
 
 image:
-  repository: directxman12/k8s-prometheus-adapter-amd64
+  repository: superedge.tencentcloudcr.com/superedge/k8s-prometheus-adapter
   tag: v0.8.4
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION

#### What this PR does / why we need it:
The helm chart package of prometheus-adapter supports arm64
